### PR TITLE
Fix variable typo in runSkuMatching

### DIFF
--- a/PriceChangesTemplate.gs
+++ b/PriceChangesTemplate.gs
@@ -279,7 +279,7 @@ function runSkuMatching() {
 
 
     const totalTime = (new Date().getTime() - startTime) / 1000;
-    statusCell.setValue(`MATCHING COMPLETE - ${matchResults.length} MFR SKUs processed in ${totalTime.toFixed(1)}s. ${totalMatches} matches. ${reviewRequiredMatchesOverall} for review.`).setBackground('#d9ead3');
+    statusCell.setValue(`MATCHING COMPLETE - ${matchResults.length} MFR SKUs processed in ${totalTime.toFixed(1)}s. ${totalMatches} matches. ${reviewRequiredMatches} for review.`).setBackground('#d9ead3');
     ui.alert('Accurate SKU Matching Complete',
              `${matchResults.length} MFR SKUs processed in ${totalTime.toFixed(1)}s.\n` +
              `Total matches: ${totalMatches}\n` +


### PR DESCRIPTION
## Summary
- correct the variable name `reviewRequiredMatchesOverall` to `reviewRequiredMatches` so results show the correct count

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841c9a5ecc48326914ec3d6fdf96f54